### PR TITLE
Fix/module 07

### DIFF
--- a/code/module-07/m07-end/module07.html
+++ b/code/module-07/m07-end/module07.html
@@ -7,8 +7,8 @@
 <body>
     <h1>Test JavaScript</h1>
   <p id="date"></p>
-  <p>This page calls the script module08_main.js and is used for testing.</p>
-  <script src=".\build\module08_main.js"></script>
+  <p>This page calls the script module07_main.js and is used for testing.</p>
+  <script src=".\module07_main.js"></script>
   <noscript>You need to enable JavaScript to view the full site.</noscript>
 </body>
 </html>

--- a/code/module-07/m07-end/tsconfig.json
+++ b/code/module-07/m07-end/tsconfig.json
@@ -14,7 +14,7 @@
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "build",                        /* Redirect output structure to the directory. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */

--- a/code/module-07/m07-start/module07.html
+++ b/code/module-07/m07-start/module07.html
@@ -7,8 +7,8 @@
 <body>
     <h1>Test JavaScript</h1>
   <p id="date"></p>
-  <p>This page calls the script module08_main.js and is used for testing.</p>
-  <script src=".\build\module08_main.js"></script>
+  <p>This page calls the script module07_main.js and is used for testing.</p>
+  <script src=".\module07_main.js"></script>
   <noscript>You need to enable JavaScript to view the full site.</noscript>
 </body>
 </html>

--- a/code/module-07/m07-start/tsconfig.json
+++ b/code/module-07/m07-start/tsconfig.json
@@ -14,7 +14,7 @@
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "build",                        /* Redirect output structure to the directory. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */


### PR DESCRIPTION
* Fixed module07.html (in m07-start and m07-end) to refer to the compiled module07_main.js. 
* Also, the text has been modified to show that this HMTL files are for module07_main.js.
* Fixed tsconfig.json (in m07-start and m07-end) to export javascript files to ". /" at compile. The 6-lab content of typescript-work-external-libraries does not refer to tsconfig.json, but the output destination of the content and outDir of the tsconfig.json were misaligned. I corrected this to avoid misunderstandings.

Thanks!
Nayuta